### PR TITLE
[Fix] retry 적용과 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'com.auth0:java-jwt:4.0.0'
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework:spring-aspects'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/server/autodevlog/AutoDevLogApplication.java
+++ b/src/main/java/com/server/autodevlog/AutoDevLogApplication.java
@@ -2,8 +2,10 @@ package com.server.autodevlog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
+@EnableRetry
 public class AutoDevLogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/server/autodevlog/auth/domain/Member.java
+++ b/src/main/java/com/server/autodevlog/auth/domain/Member.java
@@ -1,6 +1,5 @@
 package com.server.autodevlog.auth.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import lombok.*;

--- a/src/main/java/com/server/autodevlog/auth/service/JwtEnum.java
+++ b/src/main/java/com/server/autodevlog/auth/service/JwtEnum.java
@@ -1,0 +1,16 @@
+package com.server.autodevlog.auth.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum JwtEnum {
+
+    ACCESS_TOKEN_SUBJECT("AccessToken"),
+    REFRESH_TOKEN_SUBJECT("RefreshToken"),
+    UUID_CLAIM("uuid"),
+    BEARER("Bearer ");
+
+    private final String value;
+}

--- a/src/main/java/com/server/autodevlog/auth/service/JwtService.java
+++ b/src/main/java/com/server/autodevlog/auth/service/JwtService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import java.util.Date;
 import java.util.Optional;
 
-import static com.server.autodevlog.auth.service.JwtString.*;
+import static com.server.autodevlog.auth.service.JwtEnum.*;
 
 @Service
 @RequiredArgsConstructor
@@ -37,9 +37,9 @@ public class JwtService {
         try {
             Date now = new Date();
             return JWT.create()
-                    .withSubject(ACCESS_TOKEN_SUBJECT)
+                    .withSubject(ACCESS_TOKEN_SUBJECT.getValue())
                     .withExpiresAt(new Date(now.getTime() + Long.parseLong(accessTokenExpirationPeriod)))
-                    .withClaim(UUID_CLAIM, userId)
+                    .withClaim(UUID_CLAIM.getValue(), userId)
                     .sign(Algorithm.HMAC512(this.secretKey));
         } catch (Exception e) {
             // 예외 처리
@@ -52,22 +52,22 @@ public class JwtService {
     public String createRefreshToken(String userId) {
         Date now = new Date();
         return JWT.create()
-                .withSubject(REFRESH_TOKEN_SUBJECT)
-                .withClaim(UUID_CLAIM, userId)
+                .withSubject(REFRESH_TOKEN_SUBJECT.getValue())
+                .withClaim(UUID_CLAIM.getValue(), userId)
                 .withExpiresAt(new Date(now.getTime() + Long.parseLong(refreshTokenExpirationPeriod)))
                 .sign(Algorithm.HMAC512(this.secretKey));
     }
 
     public Optional<String> extractAccessToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(accessHeader))
-                .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+                .filter(refreshToken -> refreshToken.startsWith(BEARER.getValue()))
+                .map(refreshToken -> refreshToken.replace(BEARER.getValue(), ""));
     }
 
     public Optional<String> extractRefreshToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(refreshHeader))
-                .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+                .filter(refreshToken -> refreshToken.startsWith(BEARER.getValue()))
+                .map(refreshToken -> refreshToken.replace(BEARER.getValue(), ""));
     }
 
     public boolean isTokenValid(String token) {
@@ -87,7 +87,7 @@ public class JwtService {
             return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
                     .build() // 반환된 빌더로 JWT verifier 생성
                     .verify(accessToken) // accessToken을 검증하고 유효하지 않다면 예외 발생
-                    .getClaim(UUID_CLAIM)
+                    .getClaim(UUID_CLAIM.getValue())
                     .asString());
         } catch (Exception e) {
             log.error("액세스 토큰이 유효하지 않습니다.");

--- a/src/main/java/com/server/autodevlog/auth/service/JwtString.java
+++ b/src/main/java/com/server/autodevlog/auth/service/JwtString.java
@@ -1,8 +1,0 @@
-package com.server.autodevlog.auth.service;
-
-public class JwtString {
-    static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
-    static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
-    static final String UUID_CLAIM = "uuid";
-    static final String BEARER = "Bearer ";
-}

--- a/src/main/java/com/server/autodevlog/blog/controller/BlogController.java
+++ b/src/main/java/com/server/autodevlog/blog/controller/BlogController.java
@@ -20,7 +20,7 @@ public class BlogController {
     private final BlogService blogService;
 
     @PostMapping("/velog-post")
-    @Operation(summary = "벨로그 포스팅 API", description = "벨로그 로그인이 구현되지 않아서, body의 token 값으로 벨로그 access_token 값을 넣어주세요.")
+    @Operation(summary = "벨로그 포스팅 API", description = "만약 서버에 저장된 벨로그 토큰이 만료되었다면 서버단에서 토큰 업데이트 후 재시도하도록 구현 하였습니다.")
     public ResponseEntity velogPosting(@AuthenticationPrincipal Member member, @RequestBody VelogPostRequestDto velogPostRequestDto) {
         blogService.postToVelog(member, velogPostRequestDto);
         return new ResponseEntity(HttpStatus.CREATED);

--- a/src/main/java/com/server/autodevlog/blog/service/BlogService.java
+++ b/src/main/java/com/server/autodevlog/blog/service/BlogService.java
@@ -1,37 +1,55 @@
 package com.server.autodevlog.blog.service;
 
 import com.server.autodevlog.auth.domain.Member;
+import com.server.autodevlog.auth.repository.MemberRepository;
 import com.server.autodevlog.blog.dto.VelogPostRequestDto;
 import com.server.autodevlog.blog.dto.VelogPostResponseDto;
 import com.server.autodevlog.global.exception.CustomException;
 import com.server.autodevlog.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class BlogService {
+
+    private final MemberRepository memberRepository;
+
+    @Retryable(maxAttempts = 2, retryFor = CustomException.class)
     public void postToVelog(Member member, VelogPostRequestDto velogPostRequestDto) throws CustomException {
 
-        String title = velogPostRequestDto.getTitle();
-        String body = velogPostRequestDto.getBody();
-
-        String query = buildVelogQuery(title, body);
+        String query = buildVelogQuery(velogPostRequestDto);
+        String cookie = buildCookieString(member);
 
         WebClient webClient = WebClient.builder()
                 .baseUrl("https://v2.velog.io")
                 .build();
 
+        ResponseEntity<VelogPostResponseDto> response = sendPostRequest(webClient, query, cookie);
+
+        Optional.ofNullable(response.getBody()) // Response body의 null 체크
+                .map(VelogPostResponseDto::getData)
+                .map(VelogPostResponseDto.VelogResponseData::getWritePost) // Posting 실패 예외처리
+                .orElseThrow(() -> {
+                    updateVelogTokens(member, response.getHeaders()); // Token 업데이트
+                    throw new CustomException(ErrorCode.VELOG_POSTING_ERROR); // Retry 될 수 있도록 예외 Throw
+                });
+    }
+
+    private ResponseEntity<VelogPostResponseDto> sendPostRequest(WebClient webClient, String query, String cookie) {
         ResponseEntity<VelogPostResponseDto> response = webClient.post()
                 .uri("/graphql")
                 .contentType(MediaType.APPLICATION_JSON)
-                .header("Cookie", "access_token=" + member.getVelogAccessToken() + ";")
+                .header("Cookie", cookie)
                 .bodyValue(query)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError, res -> {
@@ -40,13 +58,13 @@ public class BlogService {
                 .toEntity(VelogPostResponseDto.class)
                 .block();
 
-        Optional.ofNullable(response.getBody()) // response body의 null 체크
-                .map(VelogPostResponseDto::getData)
-                .map(VelogPostResponseDto.VelogResponseData::getWritePost) // Posting 실패 예외처리
-                .orElseThrow(() -> new CustomException(ErrorCode.VELOG_POSTING_ERROR));
+        return response;
     }
 
-    private String buildVelogQuery(String title, String body) {
+    private String buildVelogQuery(VelogPostRequestDto velogPostRequestDto) {
+        String title = velogPostRequestDto.getTitle();
+        String body = velogPostRequestDto.getBody();
+
         return "{\"operationName\":\"WritePost\",\"variables\"" +
                 ":{\"title\":\"" + title + "\",\"body\":\"" + body
                 + "\",\"tags\":[],\"is_markdown\":true,\"is_temp\":false,\"is_private\":false,\"url_slug\":\""
@@ -55,5 +73,22 @@ public class BlogService {
                 "WritePost($title: String, $body: String, $tags: [String], $is_markdown: Boolean, $is_temp: Boolean, $is_private: Boolean, $url_slug: String, $thumbnail: String, $meta: JSON, $series_id: ID, $token: String) " +
                 "{\\n  writePost(title: $title, body: $body, tags: $tags, is_markdown: $is_markdown, is_temp: $is_temp, is_private: $is_private, url_slug: $url_slug, thumbnail: $thumbnail, meta: $meta, series_id: $series_id, token: $token) " +
                 "{\\n    id\\n    user {\\n      id\\n      username\\n      __typename\\n    }\\n    url_slug\\n    __typename\\n  }\\n}\\n\"}";
+    }
+
+    private String buildCookieString(Member member) {
+        String accessToken = member.getVelogAccessToken();
+        String refreshToken = member.getVelogRefreshToken();
+
+        return "access_token=" + accessToken + ";" + "refresh_token=" + refreshToken + ";";
+    }
+
+    private void updateVelogTokens(Member member, HttpHeaders httpHeaders) {
+        List<String> cookies = httpHeaders.get("Set-Cookie");
+
+        String accessToken = cookies.get(0).split(";")[0].substring(13);
+        String refreshToken = cookies.get(1).split(";")[0].substring(14);
+
+        member.setVelogTokens(accessToken, refreshToken);
+        memberRepository.save(member);
     }
 }


### PR DESCRIPTION
1. 우리 서버가 가지고 있는 벨로그 토큰이 만료되면 refresh 토큰을 통해 새로운 액세스 토큰을 발급받는 기능을 추가했습니다.
2. retry를 도입하여, 포스팅 실패 발생시 토큰 업데이트후 자동으로 재시도하도록 하였습니다.
3. 블로그 서비스의 메소드 추출, JWT Enum 도입 등 리팩토링을 했습니다.